### PR TITLE
feat: add url query parsing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,8 @@
 name: Unit Tests
 on:
   push:
+    tags:
+      - v*
     branches:
       - main
   pull_request:
@@ -45,11 +47,13 @@ jobs:
       - name: 🆙 Upload code climate test coverage report
         run: ./cc-test-reporter after-build --prefix github.com/oatovar/go-pager
   golangci-lint:
-    name: golangci-lint
+    permissions:
+      contents: read
+    name: lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          args: --verbose
+          version: latest

--- a/bind.go
+++ b/bind.go
@@ -1,0 +1,56 @@
+package pager
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+)
+
+func BindRequest(r *http.Request, out *QueryArgs) error {
+	if r == nil {
+		return fmt.Errorf("request must be non-nil reference")
+	}
+
+	if out == nil {
+		return fmt.Errorf("out must be non-nil reference")
+	}
+
+	query := r.URL.Query()
+
+	var (
+		after  = query.Get("after")
+		first  = query.Get("first")
+		before = query.Get("before")
+		last   = query.Get("last")
+	)
+
+	if len(after) > 0 {
+		out.After = &after
+	}
+
+	if len(first) > 0 {
+		val, err := strconv.Atoi(first)
+		if err != nil {
+			return err
+		}
+
+		firstUint := UintFromInt(val)
+		out.First = &firstUint
+	}
+
+	if len(before) > 0 {
+		out.Before = &before
+	}
+
+	if len(last) > 0 {
+		val, err := strconv.Atoi(last)
+		if err != nil {
+			return err
+		}
+
+		lastUint := UintFromInt(val)
+		out.Last = &lastUint
+	}
+
+	return nil
+}

--- a/bind_test.go
+++ b/bind_test.go
@@ -70,7 +70,8 @@ func TestBindRequest(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			var got QueryArgs
-			BindRequest(tc.in, &got)
+			err := BindRequest(tc.in, &got)
+			assert.Nil(t, err, "no error should be returned")
 			assert.Equal(t, *tc.expect, got)
 		})
 	}

--- a/bind_test.go
+++ b/bind_test.go
@@ -1,0 +1,77 @@
+package pager
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBindRequest(t *testing.T) {
+	tests := map[string]struct {
+		in     *http.Request
+		expect *QueryArgs
+	}{
+		"after and first defined": {
+			in: &http.Request{
+				URL: &url.URL{
+					RawQuery: "after=abcdef&first=10&before=&last=",
+				},
+			},
+			expect: &QueryArgs{
+				After: PtrFromStr("abcdef"),
+				First: PtrFromUint(10),
+			},
+		},
+		"param defined multiple times": {
+			in: &http.Request{
+				URL: &url.URL{
+					RawQuery: "after=abcdef&after=abcdefg&first=10&before=&last=",
+				},
+			},
+			expect: &QueryArgs{
+				After: PtrFromStr("abcdef"),
+				First: PtrFromUint(10),
+			},
+		},
+		"all empty": {
+			in: &http.Request{
+				URL: &url.URL{
+					RawQuery: "after=&first=&before=&last=",
+				},
+			},
+			expect: &QueryArgs{},
+		},
+		"before and last defined": {
+			in: &http.Request{
+				URL: &url.URL{
+					RawQuery: "after=&first=&before=abcdef&last=10",
+				},
+			},
+			expect: &QueryArgs{
+				Before: PtrFromStr("abcdef"),
+				Last:   PtrFromUint(10),
+			},
+		},
+		"negative last value": {
+			in: &http.Request{
+				URL: &url.URL{
+					RawQuery: "after=opaqueCursor&first=-10&before=&last",
+				},
+			},
+			expect: &QueryArgs{
+				After: PtrFromStr("opaqueCursor"),
+				First: PtrFromUint(10),
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			var got QueryArgs
+			BindRequest(tc.in, &got)
+			assert.Equal(t, *tc.expect, got)
+		})
+	}
+}

--- a/pager.go
+++ b/pager.go
@@ -48,10 +48,10 @@ func New(configs ...Config) (*Pager, error) {
 // QueryArgs captures all arguments required for GraphQL cursor based
 // pagination.
 type QueryArgs struct {
-	First  *uint   `json:"first,omitempty" schema:"first,omitempty"`
-	After  *string `json:"after,omitempty" schema:"after,omitempty"`
-	Last   *uint   `json:"last,omitempty" schema:"last,omitempty"`
-	Before *string `json:"before,omitempty" schema:"before,omitempty"`
+	First  *uint   `json:"first" schema:"first" query:"first"`
+	After  *string `json:"after" schema:"after" query:"after"`
+	Last   *uint   `json:"last" schema:"last" query:"last"`
+	Before *string `json:"before" schema:"before" query:"before"`
 }
 
 // Result represents the outcome of processing the supplied QueryArgs.

--- a/pager_test.go
+++ b/pager_test.go
@@ -71,8 +71,8 @@ func TestProcess(t *testing.T) {
 				MaxPageSize:     DefaultConfig.MaxPageSize,
 			},
 			in: &QueryArgs{
-				After:  ptrFromStr("testCursor"),
-				Before: ptrFromStr("testCursor"),
+				After:  PtrFromStr("testCursor"),
+				Before: PtrFromStr("testCursor"),
 			},
 			expect: &Result{
 				Cursor:              "",
@@ -87,8 +87,8 @@ func TestProcess(t *testing.T) {
 				MaxPageSize:     DefaultConfig.MaxPageSize,
 			},
 			in: &QueryArgs{
-				After: ptrFromStr("testCursor"),
-				First: ptrFromUint(10),
+				After: PtrFromStr("testCursor"),
+				First: PtrFromUint(10),
 			},
 			expect: &Result{
 				Cursor:              "testCursor",
@@ -102,8 +102,8 @@ func TestProcess(t *testing.T) {
 				MaxPageSize:     DefaultConfig.MaxPageSize,
 			},
 			in: &QueryArgs{
-				After: ptrFromStr("testCursor"),
-				First: ptrFromUint(125),
+				After: PtrFromStr("testCursor"),
+				First: PtrFromUint(125),
 			},
 			expect: &Result{
 				Cursor:              "testCursor",
@@ -117,7 +117,7 @@ func TestProcess(t *testing.T) {
 				MaxPageSize:     DefaultConfig.MaxPageSize,
 			},
 			in: &QueryArgs{
-				After: ptrFromStr("testCursor"),
+				After: PtrFromStr("testCursor"),
 			},
 			expect: &Result{
 				Cursor:              "testCursor",
@@ -131,8 +131,8 @@ func TestProcess(t *testing.T) {
 				MaxPageSize:     DefaultConfig.MaxPageSize,
 			},
 			in: &QueryArgs{
-				Before: ptrFromStr("testCursor"),
-				Last:   ptrFromUint(30),
+				Before: PtrFromStr("testCursor"),
+				Last:   PtrFromUint(30),
 			},
 			expect: &Result{
 				Cursor:              "testCursor",
@@ -146,8 +146,8 @@ func TestProcess(t *testing.T) {
 				MaxPageSize:     DefaultConfig.MaxPageSize,
 			},
 			in: &QueryArgs{
-				Before: ptrFromStr("testCursor"),
-				Last:   ptrFromUint(125),
+				Before: PtrFromStr("testCursor"),
+				Last:   PtrFromUint(125),
 			},
 			expect: &Result{
 				Cursor:              "testCursor",
@@ -161,7 +161,7 @@ func TestProcess(t *testing.T) {
 				MaxPageSize:     DefaultConfig.MaxPageSize,
 			},
 			in: &QueryArgs{
-				Before: ptrFromStr("testCursor"),
+				Before: PtrFromStr("testCursor"),
 			},
 			expect: &Result{
 				Cursor:              "testCursor",
@@ -177,12 +177,4 @@ func TestProcess(t *testing.T) {
 			assert.Equal(t, got, tc.expect, "results should be equal")
 		})
 	}
-}
-
-func ptrFromStr(in string) *string {
-	return &in
-}
-
-func ptrFromUint(in uint) *uint {
-	return &in
 }

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,18 @@
+package pager
+
+func PtrFromStr(in string) *string {
+	return &in
+}
+
+func PtrFromUint(in uint) *uint {
+	return &in
+}
+
+// UintFromInt safely converts an int to an uint preventing wrap around
+// values from being returned.
+func UintFromInt(in int) uint {
+	if in < 0 {
+		in *= -1
+	}
+	return uint(in)
+}

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,0 +1,13 @@
+package pager
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUintFromInt(t *testing.T) {
+	var expect uint = 10
+	got := UintFromInt(-10)
+	assert.Equal(t, expect, got)
+}


### PR DESCRIPTION
Allow easy interoperability with the standard http package and other popular packages such as `gorilla/schema`, `fibergo/fiber` and `labstack/echo`.